### PR TITLE
use Ownable to create whitelist of favored parties

### DIFF
--- a/contracts/AdvanceRequirement.sol
+++ b/contracts/AdvanceRequirement.sol
@@ -3,32 +3,42 @@ pragma solidity ^0.6.0;
 import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol";
 
 //work in progress -- use at own risk.
-//simple boolean Advance Requirement confirmation / condition precedent to deal closing
+/* simple boolean Advance Requirement confirmation / condition precedent to deal closing
+** owner inputs Advance Requirement details and whitelist of addresses that are controlled by the favored party
+** favored party confirms when Advance Requirement is satisfied */
 
 contract Requirement is Ownable {
     bool private requirementSatisfied = false;
     //mapping for favored party's address
     mapping(address => bool) favored;
-    address whitelist;
+    address[] whitelist;
     string condition;
+    // event to be added when address added to whitelist || address given favored status
+    // event to be added when requirementSatisfied == true
     
     //allow owner to create whitelist of favored party address[es]
-    function permitAccess(address _addr) public onlyOwner {
+    function permitFavored(address _addr) public onlyOwner {
         favored[_addr] = true;
+        whitelist.push(_addr);
     }
     
     function favoredParty(address _addr) public view returns(bool) {
         return favored[_addr];
     }
     
-     function revokeAccess(address _addr) public onlyOwner {
+     function revokeFavored(address _addr) public onlyOwner {
         favored[_addr] = false;
     }
-    
-    //set out Advance Requirement details
-    function enterCondition(string memory _reference) public {
-        //add ability for favored party to input string condition
-        require(favoredParty(favored), "Caller not favored party");
+        
+    /*** optional modifier so only the favored party may call other functions
+    modifier onlyFavored() {
+        require(favored[msg.sender] == true, "Only the favored party can call this.");
+        _;
+    } ***/
+        
+    //owner sets out Advance Requirement details
+    function enterCondition(string memory _reference) public onlyOwner {
+        require(requirementSatisfied == false, "Advance Requirement already satisfied, cannot change details");
         condition = _reference;
     }
 
@@ -40,9 +50,9 @@ contract Requirement is Ownable {
         return requirementSatisfied;
     }
     
-    //Favored Party must confirm the Requirement is satisfied
+    //Favored party must confirm the Requirement is satisfied
     function confirmSubmit() public {
-        require(favoredParty(favored), "Caller not favored party");
+        require(favored[msg.sender] == true, "Only favored party may confirm Advance Requirement is satisfied");
         require(requirementSatisfied == false, "Advance Requirement already satisfied");
         requirementSatisfied = true;
     }

--- a/contracts/AdvanceRequirement.sol
+++ b/contracts/AdvanceRequirement.sol
@@ -1,17 +1,34 @@
-pragma solidity ^0.5.17;
+pragma solidity ^0.6.0;
 
-//work in progress, based off of lexDAO's Shame.sol -- use at own risk.
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol";
+
+//work in progress -- use at own risk.
 //simple boolean Advance Requirement confirmation / condition precedent to deal closing
 
-contract Requirement {
+contract Requirement is Ownable {
     bool private requirementSatisfied = false;
-    //consider mapping for favored party's address
+    //mapping for favored party's address
+    mapping(address => bool) favored;
+    address whitelist;
     string condition;
+    
+    //allow owner to create whitelist of favored party address[es]
+    function permitAccess(address _addr) public onlyOwner {
+        favored[_addr] = true;
+    }
+    
+    function favoredParty(address _addr) public view returns(bool) {
+        return favored[_addr];
+    }
+    
+     function revokeAccess(address _addr) public onlyOwner {
+        favored[_addr] = false;
+    }
     
     //set out Advance Requirement details
     function enterCondition(string memory _reference) public {
-        //add ability for favored party to input string condition, only once
-        require(msg.sender == 0xb7f49E02552751b249caE86959fD50D887708B1D, "Caller not favored party");
+        //add ability for favored party to input string condition
+        require(favoredParty(favored), "Caller not favored party");
         condition = _reference;
     }
 
@@ -25,7 +42,7 @@ contract Requirement {
     
     //Favored Party must confirm the Requirement is satisfied
     function confirmSubmit() public {
-        require(msg.sender == 0xb7f49E02552751b249caE86959fD50D887708B1D, "Caller not favored party");
+        require(favoredParty(favored), "Caller not favored party");
         require(requirementSatisfied == false, "Advance Requirement already satisfied");
         requirementSatisfied = true;
     }


### PR DESCRIPTION
May need to create a whitelist struct of addresses and boolean favored status, see https://medium.com/51nodes/solidity-library-for-array-of-type-address-e40c36784ab2 

would need proper require() syntax to show caller is in whitelist and is favored